### PR TITLE
Remove Redis env and services from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,3 @@ jobs:
   ci:
     name: Continuous Integration
     uses: WyriHaximus/github-workflows/.github/workflows/package.yaml@main
-    with:
-      env: "{\"REDIS_DSN\":\"redis://redis:6379/6\"}"
-      services: "{\"redis\":{\"image\":\"redis\",\"options\":\"--health-cmd \\\"redis-cli ping\\\" --health-interval 1s --health-timeout 5s --health-retries 50\"}}"


### PR DESCRIPTION
Removed environment and services configuration for CI job as nothing in this package requires Redis